### PR TITLE
v0.3.6c patching CORs policy on API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NetGPT: The Network Engineering GPT
 
-[![License](https://img.shields.io/github/license/kennethgrace/netgpt?color=yellow&style=flat-square)](https://mit-license.org)
+[![License](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](https://mit-license.org)
 [![Docker Hub](https://img.shields.io/badge/Docker_Hub-NetGPT-blue?style=flat-square)](https://hub.docker.com/r/kennethgrace/netgpt-webui)
 
 ## Introduction
@@ -42,7 +42,7 @@ When using Docker, you can provide the certificates using the following commands
 _For Web UI:_
 
 ```bash
-docker run -d -p 80:8080 -p 443:8443 \
+docker run -d -p 80:8080 -p 443:8443 --name netgpt-webui \
  -v /etc/ca-certificates/certs/www.crt:/etc/nginx/certs/certificate.crt \
  -v /etc/ca-certificates/certs/www.key:/etc/nginx/certs/certificate.key \
  kennethgrace/netgpt-webui
@@ -51,22 +51,26 @@ docker run -d -p 80:8080 -p 443:8443 \
 _For API:_
 
 ```bash
-docker run -d -p 49488:49488 \
+docker run -d -p 49488:49488 --name netgpt-api \
  -v /etc/ca-certificates/certs/api.crt:/app/certs/api.crt \
  -v /etc/ca-certificates/certs/api.key:/app/certs/api.key \
  kennethgrace/netgpt-api
 ```
 
-#### Using KeyCloak
+#### Using a KeyCloak Server
 
-If you plan to use the KeyCloak authentication, you will need to provide the KeyCloak certificate as well. You can
-provide the KeyCloak container with certificates using the following command:
+If you plan to use KeyCloak authentication, you will need to provide the KeyCloak certificate as well. You can provide the KeyCloak container with certificates using the same volume mounting method as for the application and API.
+
+Normally, you would run KeyCloak in production mode on a dedicated node, but for a quick setup, you can run KeyCloak in development mode locally. To run KeyCloak in development mode, use the following command:
 
 ```bash
-docker run -d -p 7080:8080 -p 7443:8443 \
+docker run -d -p 8080:8443 -p 8443:8443 --name keycloak \
  -v /etc/ca-certificates/certs/auth.crt:/etc/x509/https/tls.crt \
  -v /etc/ca-certificates/certs/auth.key:/etc/x509/https/tls.key \
- quay.io/keycloak/keycloak:latest
+ -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=keycloak \
+  quay.io/keycloak/keycloak:latest start-dev --https-port=8443 \
+ --https-certificate-file=/etc/x509/https/tls.crt \
+ --https-certificate-key-file=/etc/x509/https/tls.key
 ```
 
 ### Docker Compose

--- a/api/config/config.yml
+++ b/api/config/config.yml
@@ -3,10 +3,10 @@
 # This file is in YAML format. See http://yaml.org/ for more information.
 server:
   allowed_origins: # List of allowed origins for CORS requests. This should be the URL of the frontends.
-    - https://*
+    - *
 authentication:
   provider: keycloak # Authentication provider to use. Currently only keycloak is supported.
-  server: https://localhost:7443 # URL of the authentication server
+  server: https://localhost:8443 # URL of the authentication server
   realm: netgpt # Name of the authentication realm
   clientId: netgpt # Name of the authentication client
   # The API should receive its client secret from the `AUTH_CLIENT_SECRET` environment variable or a configured secret manager.

--- a/api/config/netgpt.yml
+++ b/api/config/netgpt.yml
@@ -3,12 +3,11 @@
 ---
 name: NetGPT # Name of the AI.
 prompt: |
-  You are NetGPT. You have a charming professional personality.
+  You are NetGPT. You have a sarcastic humorous personality.
   You are an AI assistant for network engineers.
   You are able to perform troubleshooting actions on a network.
   If the engineer asks you to do something you can't do, you will
-  tell them that you can't do it. Always provide your response in
-  Markdown format.
+  tell them that you can't do it.
 max_tokens: 8000 # Maximum number of tokens to generate.
 temperature: 1 # Controls the determinism of the AI. 0.0 is the most deterministic, 1.0 is the least deterministic.
 top_p: 0.6 # Controls the diversity (sampling) of the AI. 0.0 is the least diverse, 1.0 is the most diverse.

--- a/api/environment.py
+++ b/api/environment.py
@@ -31,11 +31,11 @@ class AuthenticationServerInformation(BaseModel):
         """
         configuration = load_config_file("authentication")
         # Override the configuration with environment variables
-        configuration["provider"] = os.getenv("AUTH_PROVIDER", None) or configuration["provider"]
-        configuration["server"] = os.getenv("AUTH_SERVER", None) or configuration["server"]
-        configuration["realm"] = os.getenv("AUTH_REALM", None) or configuration["realm"]
-        configuration["clientId"] = os.getenv("AUTH_CLIENT_ID", None) or configuration["clientId"]
-        configuration["clientSecret"] = os.getenv("AUTH_CLIENT_SECRET", None) or configuration["clientSecret"]
+        configuration["provider"] = os.getenv("AUTH_PROVIDER", configuration["provider"])
+        configuration["server"] = os.getenv("AUTH_SERVER", configuration["server"])
+        configuration["realm"] = os.getenv("AUTH_REALM", configuration["realm"])
+        configuration["clientId"] = os.getenv("AUTH_CLIENT_ID", configuration["clientId"])
+        configuration["clientSecret"] = os.getenv("AUTH_CLIENT_SECRET", configuration["clientSecret"])
         return cls(**configuration)
 
 
@@ -45,7 +45,7 @@ class NetGPTServerInformation(BaseModel):
     needed to initialize the NetGPT service.
     """
 
-    allowed_origins: list[str] = ["https://localhost", "https://localhost:8443"]
+    allowed_origins: list[str]
 
     @classmethod
     def load(cls) -> NetGPTServerInformation:
@@ -54,7 +54,8 @@ class NetGPTServerInformation(BaseModel):
         """
         configuration = load_config_file("server")
         # Override the configuration with environment variables
-        configuration["allowed_origins"] = os.getenv("ALLOWED_ORIGINS", None) or configuration["allowed_origins"]
+        environment_origins = os.getenv("ALLOWED_ORIGINS", None).split(",")
+        configuration["allowed_origins"] = environment_origins or configuration["allowed_origins"]
         return cls(**configuration)
 
 


### PR DESCRIPTION
I'm attempting to loosen the default CORs policy and pass environment variables to CORs easily with comma-seperation